### PR TITLE
Added OSSEC template mapping information

### DIFF
--- a/data-fields.rst
+++ b/data-fields.rst
@@ -23,3 +23,5 @@ Fields are mapped to their proper type using template files, found in
   ``logstash-*`` indices
 | ``beats-template.json`` - mapping information for logs going into
   ``logstash-beats-*`` indices.
+| ``logstash-ossec-template.json`` - mapping information for logs going into
+  ``logstash-ossec-*`` indices.


### PR DESCRIPTION
Don't know if the move to Wazuh is the reason why that wasn't documented, but this template was missing here.