### PR TITLE
Updated Wazuh link

### DIFF
--- a/wazuh.rst
+++ b/wazuh.rst
@@ -58,7 +58,7 @@ Adding Agents
 Please note! It is important to ensure that you download the agent that matches the version of your Wazuh server. For example, if your Wazuh server is version 3.8.2, then you will want to deploy Wazuh agent version 3.8.2.
 
 | Once you've installed the Wazuh agent on the host(s) to be monitored, then perform the steps defined here:
-| https://documentation.wazuh.com/current/user-manual/agents/registering-agents/register-agent-manual.html
+| https://documentation.wazuh.com/3.8/user-manual/agents/command-line/register.html#command-line-register
 
 You may need to run `<so-allow>`_ to allow traffic from the IP address of your Wazuh agent(s).
 


### PR DESCRIPTION
The link for registering the agents didn't exit.  I think the intended link for registering agents is the one I've updated it to as those instructions worked for me.