### PR TITLE
Special Characters in Modify SIDS

### DIFF
--- a/managing-alerts.rst
+++ b/managing-alerts.rst
@@ -105,6 +105,15 @@ Modify the SID
        modify:
          - '2019401 "seconds \d+" "seconds 3600"'
 
+If you need to modify a part of a rule that contains a special character, such as a $ in variable names, the special character needs to be escapted in the ``search`` part of the modify string. See the example below:
+
+::
+
+    idstools:
+      sids:
+        modify:
+          - '2826931 "\$EXTERNAL_NET" "!$HOME_NET"'
+          
 - From the manager, run:
 
   ::


### PR DESCRIPTION
Add a note about needing to escape special characters in the search part of the modify string.