### PR TITLE
Edited heavy node ingest like it's really working now

### DIFF
--- a/ingest.rst
+++ b/ingest.rst
@@ -52,7 +52,7 @@ Manager + Search
 
 Heavy
 -----
-| Pipeline: Filebeat [Heavy Node] --> Logstash [Heavy] --> ES Ingest [Heavy] 
+| Pipeline: Filebeat [Heavy Node] --> Logstash [Heavy] --> Redis [Heavy] <--> Logstash [Heavy] --> ES Ingest [Heavy] 
 | Logs: Zeek, Suricata, Wazuh, Osquery/Fleet, syslog
 
 Search


### PR DESCRIPTION
Edited heavy node ingest like it's really working now:
`Pipeline: Filebeat [Heavy Node] --> Logstash [Heavy] --> Redis [Heavy] <--> Logstash [Heavy] --> ES Ingest [Heavy]`