### PR TITLE
Replace suripins with suri_pins

### DIFF
--- a/suricata.rst
+++ b/suricata.rst
@@ -65,7 +65,7 @@ To pin Suricata workers to specific CPUs:
 
   ::
   
-     suripins:  
+     suri_pins:  
        - <cpu_1>  
        - <cpu_2>  
        - <cpu_3> 


### PR DESCRIPTION
"suripins:
  - <cpu_1>
  - <cpu_2>
  - <cpu_3>"

should be:

"suri_pins:
  - <cpu_1>
  - <cpu_2>
  - <cpu_3>"

analogous to zeek_pins, right?