### PR TITLE
FIX: HDD reqs for IDH

### DIFF
--- a/hardware.rst
+++ b/hardware.rst
@@ -148,7 +148,7 @@ Since receiver nodes only run :ref:`logstash` and :ref:`redis`, they don't requi
 Intrusion Detection Honeypot (IDH) Node
 ---------------------------------------
 
-For an :ref:`idh` node, the overall system requirements are low: 1GB RAM, 2x CPU, 1x NIC, and 100GB disk space.
+For an :ref:`idh` node, the overall system requirements are low: 1GB RAM, 2x CPU, 1x NIC, and 200GB disk space.
 
 Sensor Hardware Considerations
 ------------------------------


### PR DESCRIPTION
During enrollment setup complains about not enough storage on a box with 160GB and it mentions that the server needs at least 200GB.