### PR TITLE
Add domain to Firewall checklist

### DIFF
--- a/firewall.rst
+++ b/firewall.rst
@@ -21,6 +21,7 @@ When configuring network firewalls for Internet-connected deployments (non-:ref:
 - sigs.securityonion.net (Signature files for Security Onion containers)  
 - ghcr.io (Container downloads)  
 - rules.emergingthreatspro.com (Emerging Threats IDS rules)  
+- rules.emergingthreats.net (Emerging Threats IDS open rules)  
 - www.snort.org (Paid Snort Talos ruleset)  
 - github.com (Strelka and Sigma rules updates)  
 - notary.kolide.co (osquery agent update)  


### PR DESCRIPTION
`rules.emergingthreats.net` is checked in the pre-flight checks even if not needed. Added to the Firewall list.

```
[WARNING] (01/10) Could not reach https://rules.emergingthreats.net/open/, curl error code: 60
[WARNING] (02/10) Could not reach https://rules.emergingthreats.net/open/, curl error code: 60
[WARNING] (03/10) Could not reach https://rules.emergingthreats.net/open/, curl error code: 60
[WARNING] (04/10) Could not reach https://rules.emergingthreats.net/open/, curl error code: 60
[WARNING] (05/10) Could not reach https://rules.emergingthreats.net/open/, curl error code: 60
[WARNING] (06/10) Could not reach https://rules.emergingthreats.net/open/, curl error code: 60
[WARNING] (07/10) Could not reach https://rules.emergingthreats.net/open/, curl error code: 60
[WARNING] (08/10) Could not reach https://rules.emergingthreats.net/open/, curl error code: 60
[WARNING] (09/10) Could not reach https://rules.emergingthreats.net/open/, curl error code: 60
[WARNING] (10/10) Could not reach https://rules.emergingthreats.net/open/, curl error code: 60
[ERROR  ] Could not reach https://rules.emergingthreats.net/open/ after 10 attempts.
[INFO   ] Successfully reached https://rules.emergingthreatspro.com/

  FAILURE

Pre-flight checks could not complete.
```