### PR TITLE
Update directory location of root ca certificate

### DIFF
--- a/beats.rst
+++ b/beats.rst
@@ -95,7 +95,7 @@ Next make your config look like the one below. Note that the paths are not the s
       beats {
         port => "5044"
         ssl => true
-        ssl_certificate_authorities => ["/usr/share/logstash/myca.crt"]
+        ssl_certificate_authorities => ["/usr/share/logstash/certs/myca.crt"]
         ssl_certificate => "/usr/share/logstash/certs/mybeats.crt"
         ssl_key => "/usr/share/logstash/certs/mybeats.key"
         tags => [ "beat-ext" ]


### PR DESCRIPTION
The directory location of the root ca certificate inside logstash's docker container should be the same as for "mybeats.crt" and "mybeats.key" since they are all put inside the directory "/opt/so/saltstack/local/salt/logstash/etc/certs/"