### PR TITLE
Update soc-customization.rst - Add Alert Queries Customization

### DIFF
--- a/soc-customization.rst
+++ b/soc-customization.rst
@@ -50,7 +50,7 @@ Another possible SOC customization is the session timeout. The default timeout f
 Alerts
 ------
 
-The :ref:`alerts` interface is a simplified version of the :ref:`hunt` interface by default. If you'd prefer the additional options of the :ref:`hunt` interface while reviewing your :ref:`alerts` queue, you can temporarily enable this by opening your browser console and then pasting the following:
+The :ref:`alerts` interface is a simplified version of the :ref:`hunt` interface by default.  If you'd prefer the additional options of the :ref:`hunt` interface while reviewing your :ref:`alerts` queue, you can temporarily enable this by opening your browser console and then pasting the following:
 
 ::
 
@@ -67,6 +67,24 @@ If you would like to make this change permanent, make a copy of ``soc.json``:
         cp /opt/so/saltstack/default/salt/soc/files/soc/soc.json /opt/so/saltstack/local/salt/soc/files/soc/
         
 Then edit ``/opt/so/saltstack/local/salt/soc/files/soc/`` using your favorite text editor, find the ``alerts`` section, and set ``advanced`` to ``true``. Don't forget that you will need to manually update ``soc.json`` every time you update to the latest version.
+
+Custom Alert Queries
+--------------------
+
+If you'd like to add your own custom queries , you can copy ``/opt/so/saltstack/default/salt/soc/files/soc/alerts.queries.json`` to ``/opt/so/saltstack/local/salt/soc/files/soc/alert.queries.json`` and then add new entries.
+
+For example you want to add ``GeoIP Region`` for Source/Destination IP you would first copy the ``alerts.queries.json``:
+
+::
+
+  sudo cp -n /opt/so/saltstack/default/salt/soc/files/soc/alerts.queries.json /opt/so/saltstack/local/salt/soc/files/soc/alert.queries.json
+
+Next edit the ``/opt/so/saltstack/local/salt/soc/files/soc/alerts.queries.json`` using your favorite text editor and insert the right before  ``{ "name": "Ungroup", "query": "*" }``:
+
+::
+
+{ "name": "Group By Source IP/Port/Geo, Destination IP/Port/Geo, Name", "query": "* | groupby source.ip source.port source.geo.region_iso_code destination.ip destination.port destination.geo.region_iso_code rule.name" },
+
 
 Action Menu
 -----------

--- a/soc-customization.rst
+++ b/soc-customization.rst
@@ -71,9 +71,11 @@ Then edit ``/opt/so/saltstack/local/salt/soc/files/soc/`` using your favorite te
 Custom Alert Queries
 --------------------
 
-If you'd like to add your own custom queries , you can copy ``/opt/so/saltstack/default/salt/soc/files/soc/alerts.queries.json`` to ``/opt/so/saltstack/local/salt/soc/files/soc/alert.queries.json`` and then add new entries.
+If you'd like to add your own custom queries, you can copy ``/opt/so/saltstack/default/salt/soc/files/soc/alerts.queries.json`` to ``/opt/so/saltstack/local/salt/soc/files/soc/alert.queries.json`` and then add new entries.
 
-For example you want to add ``GeoIP Region`` for Source/Destination IP you would first copy the ``alerts.queries.json``:
+To view available fields for your queries, from the drill down, when you click the arrow to expand a row in the Events table, it will show all of the individual fields from that event.   
+
+For example you want to add GeoIP Information like ``source.geo.region_iso_code`` or ``destination.geo.region_iso_code`` for Source/Destination IP you would first copy the ``alerts.queries.json``:
 
 ::
 


### PR DESCRIPTION
Added section in SOC-Customization for Custom Alert Query.  
Tested on SecOn 2.3.130

Added to the alerts.queries.json under /opt/so/saltstack/local/salt/soc/files/soc/

   { "name": "Group By Severity, Rule, Source IP/Port/Geo, Destination IP/Port/Geo, Na        me", "query": "* | groupby event.severity_label rule.name source.ip source.port sourc        e.geo.region_iso_code destination.ip destination.port destination.geo.region_iso_code         network.community_id" },
