### PR TITLE
Update appendix.rst

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -58,7 +58,7 @@ Disable services and reboot:
 Make sure docker containers are stopped:
 ::
 
-    sudo systemctl restart docker
+    sudo systemctl stop docker
     sudo docker ps
 
 If there are any remaining docker processes, stop them (replacing ``$CONT_ID`` with the actual ID):


### PR DESCRIPTION
"make sure docker containers are stopped" using "sudo systemctl restart docker" will restart the containers and won't leave them in a stopped state.  changing this to "sudo systemctl stop docker" will have better results.