### PR TITLE
Update appendix.rst

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -58,13 +58,16 @@ Disable services and reboot:
 Make sure docker containers are stopped:
 ::
 
-    sudo systemctl restart docker
+    sudo su -c "systemctl stop docker"
     sudo docker ps
 
 If there are any remaining docker processes, stop them (replacing ``$CONT_ID`` with the actual ID):
 ::
 
     sudo docker stop $CONT_ID
+
+    This can be done in one command using:
+    sudo docker ps | awk '!/CONTAINER/ { system("sudo docker stop " $1 ) }'
 
 Unmount /nsm:
 ::

--- a/appendix.rst
+++ b/appendix.rst
@@ -58,7 +58,7 @@ Disable services and reboot:
 Make sure docker containers are stopped:
 ::
 
-    sudo su -c "systemctl stop docker"
+    sudo su -c "systemctl stop docker docker.socket"
     sudo docker ps
 
 If there are any remaining docker processes, stop them (replacing ``$CONT_ID`` with the actual ID):
@@ -66,8 +66,9 @@ If there are any remaining docker processes, stop them (replacing ``$CONT_ID`` w
 
     sudo docker stop $CONT_ID
 
-    This can be done in one command using:
-    sudo docker ps | awk '!/CONTAINER/ { system("sudo docker stop " $1 ) }'
+This can also be done in one command:
+::
+    sudo docker ps | awk '!/CONTAINER/&& !// { system("sudo docker stop " $1 ) }'
 
 Unmount /nsm:
 ::


### PR DESCRIPTION
"Make sure docker containers are stopped" using "sudo systemctl restart docker" gets an error and also would start docker back up. Changing this to sudo su -c "systemctl stop docker" will stop docker and will not give an error if the user has sudo access.

I also added a one-liner to stop the remaining docker containers.


I have read the CLA Document and I hereby sign the CLA